### PR TITLE
Fix hostname in sh-interactive on Linux

### DIFF
--- a/host/tarball/share/myx.common/include/console/bash/sh-interactive
+++ b/host/tarball/share/myx.common/include/console/bash/sh-interactive
@@ -2,4 +2,4 @@ if [ -z "$PS1" ]; then
 	echo "myx.common: sh-interactive" >&2
 fi
 . /usr/local/share/myx.common/include/console/bash/common
-export PS1="`whoami`@\\H:\\w % "
+export PS1="`whoami`@`hostname`:\\w % "

--- a/sh-scripts/install-myx.common.sh
+++ b/sh-scripts/install-myx.common.sh
@@ -44,6 +44,7 @@ if test `id -u` = 0 ; then
 				;;
 	        FreeBSD)
 	       		echo "Using: freebsd"
+			pkg bootstrap -y
 				[ ! -z "$( pkg info | grep ca_root )" ] || pkg install -y ca_root_nss
 	        	FETCH="https://github.com/myx/os-myx.common-freebsd/archive/master.tar.gz"
 	        	UPACK(){ tar -xzf - --strip-components 3 -C "$1" '**/host/tarball/*' ; }


### PR DESCRIPTION
At least hostname now shows on both FreeBSD & Ubuntu. Also, pkg bootstrap on FreeBSD